### PR TITLE
Add testing for Airflow 1.10.6 and note about unlisted requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,15 @@ workflows:
       - py38
       - py37
       - py36
-      - py36-compat
+      - py36-compat-1-10-2
+      - py36-compat-1-10-6
   nightly:
     jobs:
       - py38
       - py37
       - py36
-      - py36-compat
+      - py36-compat-1-10-2
+      - py36-compat-1-10-6
     triggers:
       - schedule:
           cron: "1 1 * * *"
@@ -73,9 +75,16 @@ jobs:
       - run_tests:
           python_version: "py36-airflow"
 
-  py36-compat:
+  py36-compat-1-10-2:
     docker:
       - image: circleci/python:3.6
     steps:
       - run_tests:
           python_version: "py36-airflow1.10.2"
+
+  py36-compat-1-10-6:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - run_tests:
+          python_version: "py36-airflow1.10.6"

--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ To upload the release, run
 $ make upload-release
 ```
 NB You will be prompted for a pypi username and password.
+
+## Notes about previous versions
+
+* apache-airflow 1.10.6
+
+This version has an unmet / unlisted dependecy on `blinker`. The `blinker` module must be installed when
+installing this version of apache-airflow.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="airflow-spell",
-    version="0.0.2",
+    version="0.0.3",
     author="Dan O'Donovan",
     author_email="dan.odonovan@healx.io",
     description="Apache Airflow integration for spell.run",

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     py{36,37,38}-airflow
     py36-airflow1.10.2
+    py36-airflow1.10.6
 [pytest]
 norecursedirs=
 [flake8]
@@ -21,6 +22,8 @@ changedir = {toxinidir}
 deps=
     airflow: apache-airflow==1.10.11
     airflow1.10.2: apache-airflow==1.10.2
+    airflow1.10.6: apache-airflow==1.10.6
+    airflow1.10.6: blinker==1.4
     -r{toxinidir}/dev-requirements.txt
 commands=
     pytest tests


### PR DESCRIPTION
It seems that airflow 1.10.6 has an unlisted dependency on `blink` - this tests 1.10.6 and makes a note of the dependency. 