### PR TITLE
Set spell owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,29 @@ The following fields in the connection map to the spell.run authentication syste
 - `host: Optional[str]` your spell.run "owner" - the entity that "owns" some object in spell - useful if 
 you wish to launch runs in a team account, where `host` could be your team name. 
 
+## Creating a spell run from Airflow `SpellRunOperator`
+
+``` python
+    hello_task = SpellRunOperator(
+        task_id="spell-task",
+        command='python -c "import sys; sys.stderr.write(sys.version)"',
+        spell_conn_id="spell_conn_id",
+        spell_owner="organisation",
+        machine_type="GPU-V100",
+    )
+```
+
+Create spell runs using the `SpellRunOperator`. 
+
+* `task_id: (str)` must be set for all DAG operators
+* `command: (str)` the command to be executed in the spell run (see 
+[spell API](https://spell.ml/docs/runs) docs)
+* `spell_conn_id: (str)` the name of the Airflow connection setup in [Connection](#Connection) section
+* `spell_ownder: (str)` by default your spell user name, over-riding this is helpful if you have an 
+organizational plan
+* `machine_type`: (str)` for setting the type of machine to run the spell run on (default "CPU")
+
+
 ## Testing
 
 Run a demonstration airflow environment;

--- a/airflow_spell/hooks/spell_client.py
+++ b/airflow_spell/hooks/spell_client.py
@@ -41,16 +41,17 @@ class SpellClient(LoggingMixin):
     DEFAULT_DELAY_MIN = 1
     DEFAULT_DELAY_MAX = 10
 
-    def __init__(self, spell_conn_id: Optional[str] = None):
+    def __init__(self, spell_conn_id: Optional[str] = None, spell_owner: Optional[str] = None):
         super().__init__()
         self.spell_conn_id = spell_conn_id
+        self.spell_owner = spell_owner
         self._hook: Optional[SpellHook] = None
         self._client: Optional[ExternalSpellClient] = None
 
     @property
     def hook(self) -> SpellHook:
         if self._hook is None:
-            self._hook = SpellHook(spell_conn_id=self.spell_conn_id)
+            self._hook = SpellHook(spell_conn_id=self.spell_conn_id, owner=self.spell_owner)
         return self._hook
 
     @property

--- a/airflow_spell/operators/spell_run.py
+++ b/airflow_spell/operators/spell_run.py
@@ -16,6 +16,11 @@ class SpellRunOperator(BaseOperator, SpellClient):
     Execute a run on Spell Run (same args as spell.client.runs.RunService
 
     Args:
+        spell_conn_id (str): Airflow connection id for spell
+        spell_owner (str, optional): Spell owner (if different from user account)
+        task_id (str, optional):
+        params (dict, optional):
+        (all commands below passed to SpellClient)
         command (str): the command to run
         machine_type (str, optional): the machine type for the run (default: CPU)
         workspace_id (int, optional): the workspace ID for code to include in the run (default: None)
@@ -64,8 +69,9 @@ class SpellRunOperator(BaseOperator, SpellClient):
     def __init__(self, **kwargs) -> None:
         BaseOperator.__init__(self, **kwargs)
         spell_conn_id = kwargs.pop("spell_conn_id")
+        spell_owner = kwargs.pop("spell_owner", None)
+        SpellClient.__init__(self, spell_conn_id=spell_conn_id, spell_owner=spell_owner)
         self.task_id = kwargs.pop("task_id")
-        SpellClient.__init__(self, spell_conn_id=spell_conn_id)
         self.params = kwargs.pop("params")
         self.kwargs = kwargs
 

--- a/dags/spell_submit.py
+++ b/dags/spell_submit.py
@@ -21,7 +21,9 @@ with DAG("Airflow-Spell-Testing", default_args=default_args, catchup=False) as d
     hello_task = SpellRunOperator(
         task_id="spell-task",
         command='python -c "import sys; sys.stderr.write(sys.version)"',
-        spell_conn_id="spell_conn_id"
+        spell_conn_id="spell_conn_id",
+        # spell_owner="organisation",  # for example, if different to username, default is username
+        # machine_type="GPU-V100",  # for example, default os "CPU"
     )
     final_task = BashOperator(task_id="final_task", bash_command="echo 'hello world'")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="airflow-spell",
-    version="0.0.3",
+    version="0.0.4",
     author="Dan O'Donovan",
     author_email="dan.odonovan@healx.io",
     description="Apache Airflow integration for spell.run",


### PR DESCRIPTION
This setting is required if you want to run your spell run as part of an organisation (and not from an individual account). 