### PR TITLE
Fix CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - save_cache:
           key: dependencies-<< parameters.python_version >>-{{ checksum "dev-requirements.txt" }}
           paths:
-            - ".cache/pip"
+            - "~/.cache/pip"
             - ".tox"
 
 jobs:


### PR DESCRIPTION
In CircleCI pip packages weren't getting cached correctly. The pip cache lives in `~/.cache` not `${PWD}/.cache`, this PR uses the correct cache location. 