### PR TITLE
[AT 850] Airflow 2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.5
 commit = True
 tag = True
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,11 @@ workflows:
       - py38
       - py37
       - py36
-      - py36-compat-1-10-2
-      - py36-compat-1-10-6
   nightly:
     jobs:
       - py38
       - py37
       - py36
-      - py36-compat-1-10-2
-      - py36-compat-1-10-6
     triggers:
       - schedule:
           cron: "1 1 * * *"
@@ -74,17 +70,3 @@ jobs:
     steps:
       - run_tests:
           python_version: "py36-airflow"
-
-  py36-compat-1-10-2:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - run_tests:
-          python_version: "py36-airflow1.10.2"
-
-  py36-compat-1-10-6:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - run_tests:
-          python_version: "py36-airflow1.10.6"

--- a/airflow_spell/hooks/spell_client.py
+++ b/airflow_spell/hooks/spell_client.py
@@ -2,8 +2,9 @@ from random import uniform
 from time import sleep
 from typing import List, Optional, Union
 
-from airflow import LoggingMixin, AirflowException
-from airflow.hooks.base_hook import BaseHook
+from airflow.exceptions import AirflowException
+from airflow.hooks.base import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
 from spell.client import SpellClient as ExternalSpellClient
 from spell.client.runs import Run as ExternalSpellRun
 from spell.client.runs import RunsService as ExternalSpellRunsService
@@ -11,7 +12,7 @@ from spell.client.runs import RunsService as ExternalSpellRunsService
 
 class SpellHook(BaseHook):
     def __init__(self, spell_conn_id="spell_default", owner: Optional[str] = None):
-        super().__init__(source=__file__)
+        super().__init__()
         self.spell_conn_id = spell_conn_id
         self.owner = owner
 

--- a/airflow_spell/hooks/spell_client.py
+++ b/airflow_spell/hooks/spell_client.py
@@ -33,6 +33,14 @@ class SpellHook(BaseHook):
         return connection_object.host
 
 
+STILL_RUNNING = [
+    ExternalSpellRunsService.BUILDING,
+    ExternalSpellRunsService.PUSHING,
+    ExternalSpellRunsService.RUNNING,
+    ExternalSpellRunsService.SAVING,
+]
+
+
 class SpellClient(LoggingMixin):
     MAX_RETRIES = 4200
     STATUS_RETRIES = 10
@@ -106,12 +114,6 @@ class SpellClient(LoggingMixin):
         if run_status == ExternalSpellRunsService.FAILED:
             raise AirflowException(f"Spell run ({run_id}) failed: {run}")
 
-        STILL_RUNNING = [
-            ExternalSpellRunsService.BUILDING,
-            ExternalSpellRunsService.PUSHING,
-            ExternalSpellRunsService.RUNNING,
-            ExternalSpellRunsService.SAVING,
-        ]
         if run_status in STILL_RUNNING:
             raise AirflowException(f"Spell ({run_id}) is not complete: {run}")
 
@@ -131,8 +133,8 @@ class SpellClient(LoggingMixin):
         changes too quickly for polling to detect a RUNNING status that moves
         quickly from STARTING to RUNNING to completed (often a failure).
 
-        :param job_id: a batch job ID
-        :type job_id: str
+        :param run_id: a spell run ID
+        :type run_id: str
 
         :param delay: a delay before polling for job status
         :type delay: Optional[Union[int, float]]
@@ -156,8 +158,8 @@ class SpellClient(LoggingMixin):
         So the status options that this will wait for are the transitions from:
         'SUBMITTED'>'PENDING'>'RUNNABLE'>'STARTING'>'RUNNING'>'SUCCEEDED'|'FAILED'
 
-        :param job_id: a batch job ID
-        :type job_id: str
+        :param run_id: a spell run ID
+        :type run_id: str
 
         :param delay: a delay before polling for job status
         :type delay: Optional[Union[int, float]]
@@ -172,8 +174,8 @@ class SpellClient(LoggingMixin):
         """
         Poll for job status using an exponential back-off strategy (with max_retries).
 
-        :param job_id: a batch job ID
-        :type job_id: str
+        :param run_id: a spell ID
+        :type run_id: str
 
         :param match_status: a list of job status to match; the batch job status are:
             'SUBMITTED'|'PENDING'|'RUNNABLE'|'STARTING'|'RUNNING'|'SUCCEEDED'|'FAILED'

--- a/airflow_spell/operators/spell_run.py
+++ b/airflow_spell/operators/spell_run.py
@@ -66,7 +66,6 @@ class SpellRunOperator(BaseOperator, SpellClient):
     ui_color = "#f2f0f6"
     ui_fgcolor = "#3c1fd1"
 
-    @apply_defaults
     def __init__(self, **kwargs) -> None:
         BaseOperator.__init__(self, **kwargs)
         spell_conn_id = kwargs.pop("spell_conn_id")

--- a/airflow_spell/operators/spell_run.py
+++ b/airflow_spell/operators/spell_run.py
@@ -94,10 +94,10 @@ class SpellRunOperator(BaseOperator, SpellClient):
             run = self.client.runs.new(**self.kwargs)
             self.spell_run_id = run.id
 
-            self.log.info(f"Spell run (spell_run_id: {self.spell_run_id}) started: {run}")
+            self.log.info("Spell run (spell_run_id: %s) started: %s" % (self.spell_run_id, str(run)))
 
         except Exception as e:
-            self.log.info(f"Spell run (task_id: {self.task_id}) failed submission")
+            self.log.info("Spell run (task_id: %s) failed submission" % self.task_id)
             raise AirflowException(e)
 
     def monitor_run(self, context: Dict):  # pylint: disable=unused-argument
@@ -108,8 +108,8 @@ class SpellRunOperator(BaseOperator, SpellClient):
         try:
             self.wait_for_run(self.spell_run_id)
             self.check_run_success(self.spell_run_id)
-            self.log.info(f"Spell run ({self.spell_run_id}) succeeded")
+            self.log.info("Spell run (%s) succeeded" % self.spell_run_id)
 
         except Exception as e:
-            self.log.info(f"Spell run ({self.spell_run_id}) failed monitoring")
+            self.log.info("Spell run (%s) failed monitoring" % self.spell_run_id)
             raise AirflowException(e)

--- a/airflow_spell/operators/spell_run.py
+++ b/airflow_spell/operators/spell_run.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 from airflow import AirflowException
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 
 from airflow_spell import SpellClient
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:1.10.10
+FROM apache/airflow:2.1.2-python3.9
 COPY . /opt/airflow-spell
 USER root
 RUN pip install /opt/airflow-spell

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,8 @@ setup(
     author_email="dan.odonovan@healx.io",
     description="Apache Airflow integration for spell.run",
     packages=find_packages(include=["airflow_spell", "airflow_spell.*"]),
-    install_requires=["apache-airflow>=1.10.2,<3.0", "spell>=0.38.4,<1.0",],
+    install_requires=[
+        "apache-airflow>=2.0,<3.0",
+        "spell>=0.38.4,<1.0",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="airflow-spell",
-    version="0.0.4",
+    version="0.0.5",
     author="Dan O'Donovan",
     author_email="dan.odonovan@healx.io",
     description="Apache Airflow integration for spell.run",

--- a/tests/operators/test_spell_run.py
+++ b/tests/operators/test_spell_run.py
@@ -4,12 +4,14 @@ from airflow_spell import SpellRunOperator
 
 def test_run_operator_can_be_created():
     run_operator = SpellRunOperator(
-        spell_conn_id="testing-spell-run-operator", task_id="testing-task-id",
+        spell_conn_id="testing-spell-run-operator",
+        task_id="testing-task-id",
     )
 
     assert_that(
         run_operator,
         has_attrs(
-            spell_conn_id="testing-spell-run-operator", task_id="testing-task-id",
+            spell_conn_id="testing-spell-run-operator",
+            task_id="testing-task-id",
         ),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist=
     py{36,37,38}-airflow
-    py36-airflow1.10.2
-    py36-airflow1.10.6
 [pytest]
 norecursedirs=
 [flake8]
@@ -20,10 +18,7 @@ line_length = 88
 setenv = AIRFLOW_GPL_UNIDECODE=yes
 changedir = {toxinidir}
 deps=
-    airflow: apache-airflow==1.10.11
-    airflow1.10.2: apache-airflow==1.10.2
-    airflow1.10.6: apache-airflow==1.10.6
-    airflow1.10.6: blinker==1.4
+    airflow: apache-airflow>=2
     -r{toxinidir}/dev-requirements.txt
 commands=
     pytest tests


### PR DESCRIPTION
Updates for airflow 2.x, this adds a lower bound `airflow>=2.0` meaning that release [0.0.4](https://github.com/healx/airflow-spell/releases/tag/v0.0.4) will be the last supporting airflow 1.x