### PR TITLE
Report spell run to XCOM

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.8
+current_version = 0.0.9
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.0.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="airflow-spell",
-    version="0.0.8",
+    version="0.0.9",
     author="Dan O'Donovan",
     author_email="dan.odonovan@healx.io",
     description="Apache Airflow integration for spell.run",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="airflow-spell",
-    version="0.0.7",
+    version="0.0.8",
     author="Dan O'Donovan",
     author_email="dan.odonovan@healx.io",
     description="Apache Airflow integration for spell.run",

--- a/src/airflow_spell/operators/spell_run.py
+++ b/src/airflow_spell/operators/spell_run.py
@@ -80,14 +80,16 @@ class SpellRunOperator(BaseOperator, SpellClient):
             kwargs.pop("default_args")
         self.kwargs = kwargs
 
-    def execute(self, context: Dict):
+    def execute(self, context: Dict) -> int:
         """
         Submit and monitor a Spell run
         :raises: AirflowException
         """
         self.submit_run(context)
         self.monitor_run(context)
-        return "Spell run execute completed."
+
+        # this return value gets pushed as XCom
+        return self.spell_run_id
 
     def submit_run(self, context: Dict):  # pylint: disable=unused-argument
         self.log.info("Running Spell run")


### PR DESCRIPTION
When `SpellRunOperator.execute()` completes, the return value gets set in Airflow XCom as 

```
{{ task_instance.xcom_pull(task_ids='spell-run-task-id', key='return_value') }}
```

This PR returns the spell run id from `.execute()` and so the spell run id will be set in XCom. 