### PR TITLE
[KGT 356] coveralls PoC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  coveralls: coveralls/coveralls@1.0.6
+
 workflows:
   on_commit:
     jobs:
@@ -49,24 +52,26 @@ commands:
             - "~/.cache/pip"
             - ".tox"
 
+      - coveralls/upload
+
 jobs:
   py38:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8-node
     steps:
       - run_tests:
           python_version: "py38-airflow"
 
   py37:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.7-node
     steps:
       - run_tests:
           python_version: "py37-airflow"
 
   py36:
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.6-node
     steps:
       - run_tests:
           python_version: "py36-airflow"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,10 @@ workflows:
     jobs:
       - py38
       - py37
-      - py36
   nightly:
     jobs:
       - py38
       - py37
-      - py36
     triggers:
       - schedule:
           cron: "1 1 * * *"
@@ -68,10 +66,3 @@ jobs:
     steps:
       - run_tests:
           python_version: "py37-airflow"
-
-  py36:
-    docker:
-      - image: cimg/python:3.6-node
-    steps:
-      - run_tests:
-          python_version: "py36-airflow"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Testing
 
+[![Coverage Status](https://coveralls.io/repos/github/healx/airflow-spell/badge.svg?branch=KGT-356-coveralls-airflow-spell-po-c)](https://coveralls.io/github/healx/airflow-spell?branch=KGT-356-coveralls-airflow-spell-po-c)
+
 Run a demonstration airflow environment;
 - `$ make build` - builds the airflow docker image with `spell` installed
 - `$ make init` - initialises databases, creates default user `airflow` password `airflow` (NB This only needs to be run once)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest==7.0.1
 twine==3.8.0
 bump2version==1.0.1
 wheel==0.37.1
+pytest-cov==4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ deps=
     airflow: apache-airflow>=2
     -r{toxinidir}/dev-requirements.txt
 commands=
-    pytest tests
+    pytest --cov=airflow_spell tests

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ deps=
     airflow: apache-airflow>=2
     -r{toxinidir}/dev-requirements.txt
 commands=
-    pytest --cov=airflow_spell tests
+    pytest --cov=airflow_spell --cov-report lcov:./coverage/lcov.info tests


### PR DESCRIPTION
Add test coverage and upload results to coveralls.io

* add `pytest-cov` to measure test coverage
* add coveralls CI orb
* deprecate python 36 (LCOV not supported)

https://coveralls.io/github/healx/airflow-spell